### PR TITLE
Added dependency for EJSON

### DIFF
--- a/package.js
+++ b/package.js
@@ -7,7 +7,7 @@ Package.describe({
 
 Package.onUse(function (api) {
 
-    api.use('ejson');
+    api.use(['ejson', 'underscore']);
 
     api.addFiles(['sjcl.js', 'crypto.js'], ['client', 'server']);
 

--- a/package.js
+++ b/package.js
@@ -6,6 +6,9 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+
+    api.use('ejson');
+
     api.addFiles(['sjcl.js', 'crypto.js'], ['client', 'server']);
 
     api.export("sjcl");


### PR DESCRIPTION
Build sometimes failed because dependency declaration for EJSON or Underscore was missing
